### PR TITLE
Use import from XML to create game_appointments

### DIFF
--- a/NOTIFICATIONS-TODO-LIST.md
+++ b/NOTIFICATIONS-TODO-LIST.md
@@ -44,10 +44,10 @@
   * When: A user clicks preview messages
   * Then: The user is shown the message to be sent
 
-* [x] A user can send sms reminders for a tournament round's game appointments
+* [x] A user can send sms notifications for a tournament round's game appointments
 
   * Given: A round with several game appointments
-  * When: A user clicks "send sms reminders"
+  * When: A user clicks "send sms notifications"
   * Then: Texts are sent to each attendee with `receive_sms: true` with the game appointment details
 
 * [x] A user can opt to receive sms notifications on the attendee form
@@ -57,7 +57,7 @@
 
 ### Refactoring TODO's:
 
-* Move the send_sms_reminders into a workflow object
+* Move the send_sms_notifications into a workflow object
 * Add an editable preview message form
 * Add tests
 * Improve UI

--- a/NOTIFICATIONS-TODO-LIST.md
+++ b/NOTIFICATIONS-TODO-LIST.md
@@ -64,3 +64,4 @@
 * Add edit view and action to rounds
 * make a form for adding rounds with a game
 * prevent duplicate round numbers for a tournament
+* Remove timezone migration for game appointments

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -58,13 +58,13 @@ class RoundsController < ApplicationController
     end
   end
 
-  def send_sms_reminders
+  def send_sms_notifications
     game_appointments = @round.game_appointments
     game_appointments.each do |game_appointment|
-      send_reminder(game_appointment.attendee_one, game_appointment) if game_appointment.attendee_one.receive_sms
-      send_reminder(game_appointment.attendee_two, game_appointment) if game_appointment.attendee_two.receive_sms
+      send_notification(game_appointment.attendee_one, game_appointment) if game_appointment.attendee_one.receive_sms
+      send_notification(game_appointment.attendee_two, game_appointment) if game_appointment.attendee_two.receive_sms
     end
-    redirect_to rounds_url, notice: 'Reminders Sent'
+    redirect_to rounds_url, notice: 'Notifications Sent'
   end
 
   def delete_all_game_appointments
@@ -84,7 +84,7 @@ class RoundsController < ApplicationController
     params.require(:round_import).permit(:file)
   end
 
-  def send_reminder(attendee, game_appointment)
+  def send_notification(attendee, game_appointment)
     opponent = game_appointment.attendee_one == attendee ? game_appointment.attendee_two.full_name : game_appointment.attendee_one.full_name
     recipient = "#{attendee.local_phone}"
     message = "Hello #{attendee.full_name}. You are scheduled to play #{opponent} in #{game_appointment.location} at #{game_appointment.time}."

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -9,7 +9,7 @@ class RoundsController < ApplicationController
 
   def index
     # @tournaments = Tournament.all
-    @rounds = Round.all
+    @rounds = Round.order('rounds.number ASC').all
     if @rounds.length.zero?
       flash[:alert] = 'You have no rounds. Create one now to get started.'
     end
@@ -59,12 +59,20 @@ class RoundsController < ApplicationController
   end
 
   def send_sms_notifications
+    tournament = Tournament.find(@round.tournament_id)
     game_appointments = @round.game_appointments
+    notifications_sent = 0
     game_appointments.each do |game_appointment|
-      send_notification(game_appointment.attendee_one, game_appointment) if game_appointment.attendee_one.receive_sms
-      send_notification(game_appointment.attendee_two, game_appointment) if game_appointment.attendee_two.receive_sms
+      if game_appointment.attendee_one.receive_sms
+        send_notification(game_appointment.attendee_one, tournament, @round, game_appointment)
+        notifications_sent += 1
+      end
+      if game_appointment.attendee_two.receive_sms
+        send_notification(game_appointment.attendee_two, tournament, @round, game_appointment)
+        notifications_sent += 1
+      end
     end
-    redirect_to rounds_url, notice: 'Notifications Sent'
+    redirect_to round_path(@round), notice: "#{notifications_sent} #{'notification'.pluralize(notifications_sent)} sent."
   end
 
   def delete_all_game_appointments
@@ -73,6 +81,13 @@ class RoundsController < ApplicationController
     redirect_to round_path(@round), notice: count.to_s + " game #{"appointment".pluralize(count)} deleted."
   end
 
+  def update_notification_message
+    if @round.update(update_notification_message_params)
+      redirect_to round_path(@round), notice: 'Round was successfully updated.'
+    else
+      format.html { render :index }
+    end
+  end
 
   private
 
@@ -80,21 +95,51 @@ class RoundsController < ApplicationController
     @round = Round.find(params[:id])
   end
 
+  def update_notification_message_params
+    params.require(:round).permit(:notification_message)
+  end
+
   def round_import_params
     params.require(:round_import).permit(:file)
   end
 
-  def send_notification(attendee, game_appointment)
+  def send_notification(attendee, tournament, round, game_appointment)
     opponent = game_appointment.attendee_one == attendee ? game_appointment.attendee_two.full_name : game_appointment.attendee_one.full_name
     recipient = "#{attendee.local_phone}"
-    message = "Hello #{attendee.full_name}. You are scheduled to play #{opponent} in #{game_appointment.location} at #{game_appointment.time}."
+    # message = "Hello #{attendee.full_name}. You are scheduled to play
+    #{opponent} in #{game_appointment.location} at #{game_appointment.time}."
+
+    message = ""
+    message += round.notification_message + " " unless round.notification_message.blank?
+
+    message += "#{tournament.name}, Round #{round.number}: "\
+    "#{game_appointment.attendee_one.full_name} (white) vs. "\
+    "#{game_appointment.attendee_two.full_name} (black) at table "\
+    "#{game_appointment.table} (#{game_appointment.location}). "\
+    "Round #{round.number} starts at #{round.start_time.strftime('%H:%m %P')}"
+
+    message += " on #{round.start_time.strftime('%B %e, %Y')}" unless round.start_time.today?
+    message += "."
+
     puts recipient
     puts message
 
+    #TODO Deal with errors from invalid phone numbers
+
+    # @twilio_number = ENV['TWILIO_NUMBER']
+    # account_sid = ENV['TWILIO_ACCOUNT_SID']
+    # @client = Twilio::REST::Client.new account_sid, ENV['TWILIO_AUTH_TOKEN']
+    #
+    # message = @client.api.account.messages.create(
+    #   :from => @twilio_number,
+    #   :to => recipient,
+    #   :body => message,
+    # )
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def round_params
-    params.require(:round).permit(:number, :start_time, :tournament_id)
+    params.require(:round).permit(:number, :start_time, :tournament_id,
+      :notification_message)
   end
 end

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -65,9 +65,13 @@ class RoundsController < ApplicationController
       send_reminder(game_appointment.attendee_two, game_appointment) if game_appointment.attendee_two.receive_sms
     end
     redirect_to rounds_url, notice: 'Reminders Sent'
-
   end
 
+  def delete_all_game_appointments
+    count = @round.game_appointments.count
+    @round.game_appointments.destroy_all
+    redirect_to round_path(@round), notice: count.to_s + " game #{"appointment".pluralize(count)} deleted."
+  end
 
 
   private

--- a/app/models/game_appointment.rb
+++ b/app/models/game_appointment.rb
@@ -42,19 +42,19 @@ class GameAppointment < ApplicationRecord
     game_appointment
   end
 
-  # after_create :reminder
+  # after_create :notification
 
   # Notify our appointment attendee X minutes before the appointment time
-  def reminder
+  def notification
     @twilio_number = ENV['TWILIO_NUMBER']
     account_sid = ENV['TWILIO_ACCOUNT_SID']
     @client = Twilio::REST::Client.new account_sid, ENV['TWILIO_AUTH_TOKEN']
     time_str = ((self.time).localtime).strftime("%I:%M%p on %b. %d, %Y")
-    reminder = "Hi #{self.attendee}. You have a game scheduled with the following details: Opponent: #{self.oppoenent}, Time: #{time_str}, Location: #{self.location}."
+    notification = "Hi #{self.attendee}. You have a game scheduled with the following details: Opponent: #{self.oppoenent}, Time: #{time_str}, Location: #{self.location}."
     message = @client.api.account(account_sid).messages.create(
       :from => @twilio_number,
       :to => self.attendee.phone_number,
-      :body => reminder,
+      :body => notification,
     )
   end
 end

--- a/app/models/game_appointment.rb
+++ b/app/models/game_appointment.rb
@@ -5,19 +5,41 @@ class GameAppointment < ApplicationRecord
   belongs_to :attendee_two, class_name: "Attendee",  foreign_key: "attendee_two_id"
   belongs_to :round
 
-  validates :attendee_one, presence: true
-  validates :attendee_two, presence: true
+  validates :attendee_one, presence: true, uniqueness: { scope: :round,
+    message: "players can only play in one game per round" }
+  validates :attendee_two, presence: true, uniqueness: { scope: :round,
+    message: "players can only play in one game per round" }
+
   validate :compare_attendees
   validates :round, presence: true
-  validates :table, presence: true
+  validates :table, presence: true, uniqueness: { scope: :round, message: "a
+    table can only have one game per round"}
   validates :location, presence: true
   validates :time, presence: true
-  validates :time_zone, presence: true
+  # TODO: Remove time_zone
+  # validates :time_zone, presence: true
 
   def compare_attendees
     if self.attendee_one == self.attendee_two
       errors.add("Attendees", "can't be the same person")
     end
+  end
+
+  def self.assign_from_hash(round, appointment)
+    white = appointment['whitePlayer']
+    black = appointment['blackPlayer']
+    game_appointment = GameAppointment.new
+    game_appointment.attendee_one = Attendee.find_by_aga_id(white['agaId'])
+    game_appointment.attendee_two = Attendee.find_by_aga_id(black['agaId'])
+    game_appointment.round = round
+    game_appointment.table = appointment['tableNumber'].to_i
+    game_appointment.time = round.start_time
+    game_appointment.year = round.year
+
+    tournament = Tournament.find(round.tournament_id)
+    game_appointment.location = tournament.location
+
+    game_appointment
   end
 
   # after_create :reminder

--- a/app/views/registrations/_contact_info.html.haml
+++ b/app/views/registrations/_contact_info.html.haml
@@ -5,7 +5,7 @@
   .field
     = f.label :receive_text_messages
     = f.radio_button :receive_sms, true, checked: true
-    Send Me Text Message Updates and Reminders
+    Send Me Text Message Notifications
     = f.radio_button :receive_sms, false, checked: false
     Don't Send Me Any Text Messages
   .field

--- a/app/views/rounds/_form.html.haml
+++ b/app/views/rounds/_form.html.haml
@@ -1,5 +1,6 @@
 = form_for @round, :html => { :class => "form-horizontal round" } do |f|
   = render :partial => "shared/error_messages", :locals => { :resource => @round }
+  
   %fieldset
     .field
       = f.label :tournament_id

--- a/app/views/rounds/index.html.haml
+++ b/app/views/rounds/index.html.haml
@@ -9,7 +9,6 @@
       %th= model_class.human_attribute_name(:tournament)
       %th= model_class.human_attribute_name(:number)
       %th= model_class.human_attribute_name(:start_time)
-      %th= model_class.human_attribute_name(:created_at)
       %th= t '.actions', :default => t("helpers.actions")
   %tbody
     - @rounds.each do |round|
@@ -17,8 +16,7 @@
         %td= link_to round.id, round_path(round)
         %td= round.tournament.name
         %td= round.number
-        %td= round.start_time
-        %td= l round.created_at
+        %td= round.start_time.strftime('%B %e, %Y at %l:%M %p')
         %td
           = link_to "Show", round_path(round)
           = link_to "Edit", edit_round_path(round)

--- a/app/views/rounds/show.html.haml
+++ b/app/views/rounds/show.html.haml
@@ -2,7 +2,7 @@
 %h3 Round Number: #{@round.number}
 %h3 Start Time: #{@round.start_time.strftime('%B, %d, %Y')}  #{@round.start_time.strftime('%I %p')}
 %h3 Reminder Preview: This is where we can show a preview of the message and allow it to be edited?
-= form_for @import, url: import_game_appointments_path, mulitpart: true do |f|
+= form_for @import, url: import_game_appointments_path, multipart: true do |f|
   %fieldset
     %h2 Import Game Appointments
     .field
@@ -29,3 +29,8 @@
         %td= game_appointment.attendee_one.full_name
         %td= game_appointment.attendee_two.full_name
         %td= game_appointment.location
+
+%br
+= button_to "Delete All", delete_all_game_appointments_round_path(@round),
+  :method => :post,
+  :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure? This will delete ALL appointments in this round.')) }

--- a/app/views/rounds/show.html.haml
+++ b/app/views/rounds/show.html.haml
@@ -1,22 +1,12 @@
-%h2 #{@round.tournament.name}
-%h3 Round Number: #{@round.number}
-%h3 Start Time: #{@round.start_time.strftime('%B, %d, %Y')}  #{@round.start_time.strftime('%I %p')}
+%h2 #{@round.tournament.name}, Round #{@round.number}
+%time{datetime: @round.start_time} #{@round.start_time.strftime('%B %e, %Y at %l:%M %p')}
 %h3 Reminder Preview: This is where we can show a preview of the message and allow it to be edited?
-= form_for @import, url: import_game_appointments_path, multipart: true do |f|
-  %fieldset
-    %h2 Import Game Appointments
-    .field
-      = f.hidden_field :round, name: "game_appointment_import[round_id]", value: "#{@round.id}"
-    .field
-      = f.file_field :file
-      = f.submit "Upload"
 
-= button_to "Send SMS Reminders", send_sms_reminders_round_path(@round)
+= button_to "Send SMS Notifications", send_sms_notifications_round_path(@round)
 %br
 %table.semantic.fullwidth.zebra
   %thead
     %tr
-      %th= GameAppointment.human_attribute_name(:id)
       %th= GameAppointment.human_attribute_name(:table)
       %th= GameAppointment.human_attribute_name(:attendee_one)
       %th= GameAppointment.human_attribute_name(:attendee_two)
@@ -24,8 +14,7 @@
   %tbody
     - @round.game_appointments.each do |game_appointment|
       %tr
-        %td= link_to game_appointment.id, game_appointment
-        %td= game_appointment.table
+        %td= link_to game_appointment.table, edit_game_appointment_path(game_appointment)
         %td= game_appointment.attendee_one.full_name
         %td= game_appointment.attendee_two.full_name
         %td= game_appointment.location
@@ -34,3 +23,12 @@
 = button_to "Delete All", delete_all_game_appointments_round_path(@round),
   :method => :post,
   :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure? This will delete ALL appointments in this round.')) }
+
+= form_for @import, url: import_game_appointments_path, multipart: true do |f|
+  %fieldset
+    %h2 Import Game Appointments
+    .field
+      = f.hidden_field :round, name: "game_appointment_import[round_id]", value: "#{@round.id}"
+    .field
+      = f.file_field :file
+      = f.submit "Upload"

--- a/app/views/rounds/show.html.haml
+++ b/app/views/rounds/show.html.haml
@@ -2,6 +2,10 @@
 %time{datetime: @round.start_time} #{@round.start_time.strftime('%B %e, %Y at %l:%M %p')}
 %h3 Reminder Preview: This is where we can show a preview of the message and allow it to be edited?
 
+= form_for @round, url: { action: "update_notification_message" } do |f|
+  = f.text_area :notification_message
+  = f.submit "Update"
+
 = button_to "Send SMS Notifications", send_sms_notifications_round_path(@round)
 %br
 %table.semantic.fullwidth.zebra
@@ -15,8 +19,10 @@
     - @round.game_appointments.each do |game_appointment|
       %tr
         %td= link_to game_appointment.table, edit_game_appointment_path(game_appointment)
-        %td= game_appointment.attendee_one.full_name
-        %td= game_appointment.attendee_two.full_name
+        %td{:class => game_appointment.attendee_one.receive_sms ? "sms_enabled" : "sms_disabled" }
+          = game_appointment.attendee_one.full_name
+        %td{:class => game_appointment.attendee_two.receive_sms ? "sms_enabled" : "sms_disabled" }
+          = game_appointment.attendee_two.full_name
         %td= game_appointment.location
 
 %br

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,10 @@ Gocongress::Application.routes.draw do
           collection { post :import }
         end
         resources :rounds do
-          member { post :send_sms_reminders }
+          member do
+            post :send_sms_reminders
+            post :delete_all_game_appointments
+          end
           collection { post :import}
         end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,7 @@ Gocongress::Application.routes.draw do
         end
         resources :rounds do
           member do
-            post :send_sms_reminders
+            post :send_sms_notifications
             post :delete_all_game_appointments
           end
           collection { post :import}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Gocongress::Application.routes.draw do
           member do
             post :send_sms_notifications
             post :delete_all_game_appointments
+            patch :update_notification_message
           end
           collection { post :import}
         end

--- a/db/migrate/20180513144522_add_notification_message_to_rounds.rb
+++ b/db/migrate/20180513144522_add_notification_message_to_rounds.rb
@@ -1,0 +1,5 @@
+class AddNotificationMessageToRounds < ActiveRecord::Migration[5.0]
+  def change
+    add_column :rounds, :notification_message, :text
+  end
+end

--- a/spec/features/sms_notifications_spec.rb
+++ b/spec/features/sms_notifications_spec.rb
@@ -17,11 +17,11 @@ RSpec.feature 'SMS notifications', :type => :feature do
   end
   context 'signed in admin user' do
 
-    it 'can send sms reminders for a round game appointments' do
+    it 'can send sms notifications for a round game appointments' do
       click_link "Rounds"
       click_link "Show"
-      click_button "Send SMS Reminders"
-      expect(page).to have_content 'Reminders Sent'
+      click_button "Send SMS Notifications"
+      expect(page).to have_content 'Notifications Sent'
     end
 
     scenario 'allows a file upload of attendee game pairing data'


### PR DESCRIPTION
* Can now actually create game appointments! Import will need to have
  aga_ids of attendees you actually have in your DB. We might need to
  create a manual way of generating an import file for development.

* Add a "delete all" button for rounds to let a user easily get rid of
  all game appointments (probably useful in general in case of a bad
  import, but definitely useful for development testing)

* Add uniqueness validation to make sure that attendees can't play in
  more than one game per round, nor can one table be present twice